### PR TITLE
chore: replace TensoRaws org URLs with EutropicAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@
 ![MacOS](https://img.shields.io/badge/Support-MacOS-blue?logo=Apple&style=flat-square)
 ![Windows](https://img.shields.io/badge/Support-Windows-blue?logo=Windows&style=flat-square)
 ![Linux](https://img.shields.io/badge/Support-Linux-blue?logo=Linux&style=flat-square)
-[![CI-test](https://github.com/TensoRaws/Final2x/actions/workflows/CI-test.yml/badge.svg)](https://github.com/TensoRaws/Final2x/actions/workflows/CI-test.yml)
-[![CI-build](https://github.com/TensoRaws/Final2x/actions/workflows/CI-build.yml/badge.svg)](https://github.com/TensoRaws/Final2x/actions/workflows/CI-build.yml)
-[![Release](https://github.com/TensoRaws/Final2x/actions/workflows/Release.yml/badge.svg)](https://github.com/TensoRaws/Final2x/actions/workflows/Release.yml)
+[![CI-test](https://github.com/EutropicAI/Final2x/actions/workflows/CI-test.yml/badge.svg)](https://github.com/EutropicAI/Final2x/actions/workflows/CI-test.yml)
+[![CI-build](https://github.com/EutropicAI/Final2x/actions/workflows/CI-build.yml/badge.svg)](https://github.com/EutropicAI/Final2x/actions/workflows/CI-build.yml)
+[![Release](https://github.com/EutropicAI/Final2x/actions/workflows/Release.yml/badge.svg)](https://github.com/EutropicAI/Final2x/actions/workflows/Release.yml)
 ![Download](https://img.shields.io/github/downloads/TensoRaws/Final2x/total)
 ![GitHub](https://img.shields.io/github/license/TensoRaws/Final2x)
 
 A cross-platform image super-resolution tool.
 
-- News🎉: Enhance a video? Try [VSET](https://github.com/TensoRaws/VSET)!
+- News🎉: Enhance a video? Try [VSET](https://github.com/EutropicAI/VSET)!
 - News🎉: Final2x v3.0.0 is now available, support Nvidia 50 series GPUs now!
-- News🎉: We are thrilled to announce the release of Final2x v2.0.0, which marks a major milestone as we transition to utilizing [ccrestoration](https://github.com/TensoRaws/ccrestoration) (PyTorch) for our algorithm implementation.
+- News🎉: We are thrilled to announce the release of Final2x v2.0.0, which marks a major milestone as we transition to utilizing [ccrestoration](https://github.com/EutropicAI/ccrestoration) (PyTorch) for our algorithm implementation.
 
 ### Screenshots
 
@@ -28,7 +28,7 @@ A cross-platform image super-resolution tool.
 
 ### Installation
 
-##### [Download the latest release from here.](https://github.com/TensoRaws/Final2x/releases)
+##### [Download the latest release from here.](https://github.com/EutropicAI/Final2x/releases)
 
 #### Windows
 
@@ -66,8 +66,8 @@ apt install -y libomp5 xdg-utils
 
 The following references were referenced in the development of this project:
 
-- [Final2x-core](https://github.com/TensoRaws/Final2x-core)
-- [ccrestoration](https://github.com/TensoRaws/ccrestoration)
+- [Final2x-core](https://github.com/EutropicAI/Final2x-core)
+- [ccrestoration](https://github.com/EutropicAI/ccrestoration)
 - [PyTorch](https://github.com/pytorch/pytorch)
 - [ncnn](https://github.com/Tencent/ncnn)
 - [naive-ui](https://github.com/tusen-ai/naive-ui)
@@ -76,7 +76,7 @@ The following references were referenced in the development of this project:
 ### License
 
 This project is licensed under the BSD 3-Clause - see
-the [LICENSE file](https://github.com/TensoRaws/Final2x/blob/main/LICENSE) for details.
+the [LICENSE file](https://github.com/EutropicAI/Final2x/blob/main/LICENSE) for details.
 
 ### Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following references were referenced in the development of this project:
 ### License
 
 This project is licensed under the BSD 3-Clause - see
-the [LICENSE file](https://github.com/EutropicAI/Final2x/blob/main/LICENSE) for details.
+the [LICENSE file](./LICENSE) for details.
 
 ### Acknowledgements
 
@@ -84,8 +84,8 @@ Feel free to reach out to the project maintainers with any questions or concerns
 
 <a href="https://star-history.com/#TensoRaws/Final2x&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=TensoRaws/Final2x&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=TensoRaws/Final2x&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=TensoRaws/Final2x&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=EutropicAI/Final2x&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=EutropicAI/Final2x&type=Date" />
+    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=EutropicAI/Final2x&type=Date" />
   </picture>
 </a>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "3.0.0",
   "description": "A cross-platform image super-resolution tool.",
   "author": "Tohrusky",
-  "homepage": "https://github.com/TensoRaws/Final2x",
+  "homepage": "https://github.com/EutropicAI/Final2x",
   "main": "./out/main/index.js",
   "engines": {
     "node": ">=18",

--- a/resources/download-core.js
+++ b/resources/download-core.js
@@ -1,4 +1,4 @@
-// download Final2x-core from https://github.com/TensoRaws/Final2x-core/releases
+// download Final2x-core from https://github.com/EutropicAI/Final2x-core/releases
 // and put it in resources folder
 
 const fetch = (...args) => import('node-fetch').then(({ default: fetch }) => fetch(...args))
@@ -9,9 +9,9 @@ const path = require('node:path')
 
 const coreDict = {
   'macos-arm64':
-    'https://github.com/TensoRaws/Final2x-core/releases/download/2025-08-15/Final2x-core-macos-arm64.7z',
+    'https://github.com/EutropicAI/Final2x-core/releases/download/2025-08-15/Final2x-core-macos-arm64.7z',
   'windows-x64':
-    'https://github.com/TensoRaws/Final2x-core/releases/download/2025-08-15/Final2x-core-windows-x64.7z',
+    'https://github.com/EutropicAI/Final2x-core/releases/download/2025-08-15/Final2x-core-windows-x64.7z',
 }
 
 console.log('-'.repeat(50))

--- a/src/renderer/src/components/MyExternalLink.vue
+++ b/src/renderer/src/components/MyExternalLink.vue
@@ -3,11 +3,11 @@ import { FilmOutline } from '@vicons/ionicons5'
 
 class openWebsite {
   static async FinalRip(): Promise<void> {
-    window.open('https://github.com/TensoRaws/FinalRip', '_blank')
+    window.open('https://github.com/EutropicAI/FinalRip', '_blank')
   }
 
   static async VSET(): Promise<void> {
-    window.open('https://github.com/TensoRaws/VSET', '_blank')
+    window.open('https://github.com/EutropicAI/VSET', '_blank')
   }
 }
 </script>


### PR DESCRIPTION
We renamed the organization. This PR updates occurrences of:
- https://github.com/TensoRaws
to:
- https://github.com/EutropicAI

Notes:
- Only text-like files were modified; common binary/build paths skipped.
- Please review and merge when ready.
